### PR TITLE
Fixing wrong Service Provider in Readme and adding Support for Auto Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer require gliterd/laravel-backblaze-b2
 In your app.php config file add to the list of service providers:
 
 ``` php
-\Gliterd\BackblazeB2\BackblazeServiceProvider::class,
+\Gliterd\BackblazeB2\BackblazeB2ServiceProvider::class,
 ```
 Add the following to your filesystems.php config file in the disks section:
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "\\Gliterd\\BackblazeB2\\BackblazeServiceProvider"
+                "\\Gliterd\\BackblazeB2\\BackblazeB2ServiceProvider"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "\\Gliterd\\BackblazeB2\\BackblazeServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Hi,

the Service Provider is described wrong in README File. Additionally it adds Package Auto Discovery for Laravel 5.5+.