### PR TITLE
Configure adapter with both bucket id and name if specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ Add the following to your filesystems.php config file in the disks section:
     'accountId'      => '',
     'applicationKey' => '',
     'bucketName'     => '',
+    'bucketId'       => '', //optional
 ],
 ```
-## *ApplicationKey is not supported yet, please use MasterKey only*
+## Using ApplicationKey instead of MasterKey
+If you specify only the bucket name, your application key must be the master key.
+However, if you specify both bucket name and bucket id, you do not need the master key and can use a single-bucket key.
+Fetch your bucket id using the [b2 command line tool](https://www.backblaze.com/b2/docs/quick_command_line.html) `b2 get-bucket <bucketName>` 
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1.8",
-        "mhetreramesh/flysystem-backblaze": "*"
+        "mhetreramesh/flysystem-backblaze": ">=1.6.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "~4.0||~5.0",

--- a/src/BackblazeB2ServiceProvider.php
+++ b/src/BackblazeB2ServiceProvider.php
@@ -13,14 +13,16 @@ class BackblazeB2ServiceProvider extends ServiceProvider
     public function boot()
     {
         Storage::extend('b2', function ($app, $config) {
+            $bucketIsConfigured = isset($config['bucketId']) || isset($config['bucketName']);
             if (!(
-                isset($config['accountId']) ||
-                isset($config['applicationKey']) ||
-                isset($config['bucketName']))) {
-                throw new BackblazeB2Exception('Please set all configuration keys. (accountId, applicationKey, bucketName)');
+                isset($config['accountId']) &&
+                isset($config['applicationKey']) &&
+                $bucketIsConfigured
+            )) {
+                throw new BackblazeB2Exception('Please set all configuration keys. (accountId, applicationKey, [bucketId OR bucketName])');
             }
             $client = new BackblazeClient($config['accountId'], $config['applicationKey']);
-            $adapter = new BackblazeAdapter($client, $config['bucketName']);
+            $adapter = new BackblazeAdapter($client, $config['bucketName'] ?? null, $config['bucketId'] ?? null);
 
             return new Filesystem($adapter);
         });


### PR DESCRIPTION
## Description
Please see https://github.com/gliterd/flysystem-backblaze/pull/24 for the full description and reasoning behind this change.

To summarise, once the backblaze adapter can be configured with both bucket id and name, we will no longer need to use master keys to integrate with backblaze, and can use application keys which give access to a single bucket.

## Motivation and context
As above, but there's also a small change which fixes https://github.com/gliterd/laravel-backblaze-b2/issues/20

## How has this been tested?
I have loaded all of the changes I've made across several projects into my laravel project and tested put, get, exists, allFiles, delete.

## Screenshots (if appropriate)
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ ] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

> If you're unsure about any of these, don't hesitate to ask. We're here to help!

I have included the small bug fix for https://github.com/gliterd/laravel-backblaze-b2/issues/20 please advise whether you wish for me to strip that out and submit it separately.

Please also advise whether you wish for me to write tests for this.